### PR TITLE
Fixes loop in mariadb initialization

### DIFF
--- a/docker/1.7/docker-compose.yml
+++ b/docker/1.7/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   db:
-    image: mariadb
+    image: mariadb:10.8.2
     container_name: mariadb
     environment:
       - MYSQL_ROOT_PASSWORD=prestashop


### PR DESCRIPTION
Fixes loop in mariadb initialization:

`
mariadb              | 2023-01-14 13:07:13+00:00 [ERROR] [Entrypoint]: mariadbd failed while attempting to check config
mariadb              | 	command was: mariadbd --verbose --help
mariadb              | 	Can't initialize timers
`